### PR TITLE
Create cubieboard-overlay.conf

### DIFF
--- a/cubieboard-overlay.conf
+++ b/cubieboard-overlay.conf
@@ -1,0 +1,28 @@
+#/etc/portage/repos.conf/ <<< ## copy conf file to portage repo conf dir...  
+# https://wiki.gentoo.org/wiki//etc/portage/repos.conf
+## else nano/leafpad /etc/portage/repos.conf/cubieboard-overlay.conf paste contents of file in , trim out veboose ##coments as desired..
+##
+## for docker 
+## docker/gentoo package builder  https://raw.githubusercontent.com/ksa242/gentoo-cubieboard-overlay/cubieboard-overlay.conf
+## can add overlay to an emulated docker ie rpi3 gentoo-arm/qemu or simular  to build packages on AMD64 , arm64/gentoo-qemu fails atm less using 
+# qemu arm64 gentoo or gentoo varriants has been 7 hells of (not) "fun" to watch snafu on amd64 ~necrose99 , so far watch self-worth decay if you do...
+## i've tried endlessly ; but not lately , minimal debian-arm64 to chroot gentoo vol might just work...  sadomasocism/torturious comes to mind...
+#also Sabayon Linux 
+#(aka Gentoo + own distro toys , has very usable dockers, rpi3 etc..)  , packages build in container but save to dir on your localbox, and add to devboard) 
+##
+## @Docker , ADD https://raw.githubusercontent.com/ksa242/gentoo-cubieboard-overlay/cubieboard-overlay.conf /etc/portage/repos.conf/
+## happy building... 
+
+## emaint sync --repo cubieboard-overlay
+## rig keywords example , rock64/Pine64 in 64bit one would need to force ~arm64 aka AARCH64  as not officially suported in this repo...
+##  echo "*/*::cubieboard-overlay ~arm64 ~arm" >> /etc/portage/package.accept_keywords/cubieboard-overlay
+[cubieboard-overlay]
+
+# Overlay for gentoo-cubieboard-overlay
+# Maintainer: ksa242
+
+location = /usr/local/portage/gentoo-cubieboard-overlay
+sync-type = git
+sync-uri = https://github.com/ksa242/gentoo-cubieboard-overlay.git
+priority = 100
+auto-sync = yes


### PR DESCRIPTION
https://github.com/sakaki-/gentoo-on-rpi3-64bit, works well however looking to mali-gpu for Rock64 , conf file to build 64 bit mali gpu against repo if possible.  looking to adapt image or migrate to rock64 as more memory on the device.  , conf file makes for very repo install if not using layman..